### PR TITLE
refactor(client): disallow custom ids on task creation

### DIFF
--- a/docs/api/enums/errorcode.md
+++ b/docs/api/enums/errorcode.md
@@ -27,6 +27,7 @@ enum ErrorCode
 |  DATABASE\_TRANSIENT\_WRITE\_FAILURE | `"ERR_DATABASE_TRANSIENT_WRITE_FAILURE"` | The database encountered a transient error while writing data (449) |
 |  DATABASE\_UNAVAILABLE | `"ERR_DATABASE_UNAVAILABLE"` | The underlying database service is not currently available (503). |
 |  INTERCEPTOR\_NEXT\_FUNCTION\_ALREADY\_CALLED | `"ERR_INTERCEPTOR_NEXT_FUNCTION_ALREADY_CALLED"` | The next function on an interceptor was called more than one time. |
+|  INVALID\_CRON\_STRING\_INTERVAL | `"ERR_INVALID_CRON_STRING_INTERVAL"` | The provided cron string interval is invalid. |
 |  LISTENER\_DESTROYED | `"ERR_LISTENER_DESTROYED"` | The listener has been destroyed and cannot be used any more. |
 |  PROCESSING\_ALREADY\_FINISHED | `"ERR_PROCESSING_ALREADY_FINISHED"` | The operation cannot be performed because task processing has already finished. |
 |  PROCESSING\_FINISH\_IN\_PROGRESS | `"ERR_PROCESSING_FINISH_IN_PROGRESS"` | The operation cannot be performed because task processing is currently being finished. |

--- a/docs/api/interfaces/createtaskoptions.md
+++ b/docs/api/interfaces/createtaskoptions.md
@@ -15,7 +15,6 @@ interface CreateTaskOptions
 |  Property | Type | Description |
 |  --- | --- | --- |
 |  [enabled](./createtaskoptions.md#enabled-property) | `boolean` | Set to false if you don't want the task to be available for processing when it's created. |
-|  [id](./createtaskoptions.md#id-property) | `string` | Specify a custom id for the task. If no id is specified, a UUID will be generated. |
 |  [interval](./createtaskoptions.md#interval-property) | `string \| number` | Optional interval on which the task should run. It can either be set to a number, in which case it is a number of milliseconds between each run, or it can be set to a string, in which case is it a cron string (up to 1 second resolution) indicating when the task should be run.<br><br>Task executions will not stack up (i.e. a task will only actively execute once at a time), so it is not guaranteed that you will have a task execute at exactly the configured interval. For instance, if your task takes 90 seconds to process but is scheduled to run once a minute, it will only run once every 90 seconds. |
 |  [maxExecutionTimeMs](./createtaskoptions.md#maxExecutionTimeMs-property) | `number` | If specified, the duration to renew the lock while processing this task before considering processing to be hung and releasing the lock. Overrides the corresponding options on the client and task type levels. A value of 0 indicates no limit. |
 |  [scheduledTime](./createtaskoptions.md#scheduledTime-property) | `Date` | The scheduled time to run the task (or to run the first execution of the task in the case of recurring tasks). If not specified, it defaults to the creation time of the task unless a cron string is specified for the [CreateTaskOptions.interval](./createtaskoptions.md#interval-property)<!-- -->, in which case it is set to the first matching time in the cron schedule after the task creation time. |
@@ -37,18 +36,6 @@ enabled?: boolean;
 <b>Default Value:</b>
 
 true
-
-<a id="id-property"></a>
-
-### id
-
-Specify a custom id for the task. If no id is specified, a UUID will be generated.
-
-<b>Signature:</b>
-
-```typescript
-id?: string;
-```
 
 <a id="interval-property"></a>
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -163,38 +163,42 @@ export default class TaskClient {
     payload: T,
     options?: CreateTaskOptions
   ): Promise<Task<T>> {
-    const definedOptions: CreateTaskOptions = options || {};
-
-    const now = Date.now();
-
-    const task: NewTaskDocument<T> = {
-      id: definedOptions.id !== undefined ? definedOptions.id : uuid(),
-      config: {
-        type,
-        enabled:
-          definedOptions.enabled !== undefined ? definedOptions.enabled : true,
-        createTime: now,
-        lockedUntilTime: 0,
-        nextRunTime:
-          definedOptions.scheduledTime !== undefined
-            ? definedOptions.scheduledTime.getTime()
-            : computeNextRun(definedOptions.interval),
-        deliveries: 0,
-        attempts: 0,
-        runs: 0,
-        interval: definedOptions.interval,
-        ttlMs: definedOptions.ttlMs,
-        maxExecutionTimeMs: definedOptions.maxExecutionTimeMs
-      },
-      payload
-    };
+    const id = uuid();
 
     return this._interceptor.client(
       this,
       Interceptors.TaskClientOperation.Create,
-      this._client.documentRef(task.config.type, task.id),
+      this._client.documentRef(type, id),
       type,
       async () => {
+        const definedOptions: CreateTaskOptions = options || {};
+
+        const now = Date.now();
+
+        const task: NewTaskDocument<T> = {
+          id,
+          config: {
+            type,
+            enabled:
+              definedOptions.enabled !== undefined
+                ? definedOptions.enabled
+                : true,
+            createTime: now,
+            lockedUntilTime: 0,
+            nextRunTime:
+              definedOptions.scheduledTime !== undefined
+                ? definedOptions.scheduledTime.getTime()
+                : computeNextRun(definedOptions.interval),
+            deliveries: 0,
+            attempts: 0,
+            runs: 0,
+            interval: definedOptions.interval,
+            ttlMs: definedOptions.ttlMs,
+            maxExecutionTimeMs: definedOptions.maxExecutionTimeMs
+          },
+          payload
+        };
+
         const response = await this._client.createItem<NewTaskDocument<T>>(
           task
         );

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -88,14 +88,6 @@ export interface TaskClientOptions {
  */
 export interface CreateTaskOptions {
   /**
-   * Specify a custom id for the task. If no id is specified, a UUID will be
-   * generated.
-   *
-   * @public
-   */
-  id?: string;
-
-  /**
    * Set to false if you don't want the task to be available for processing
    * when it's created.
    *

--- a/src/error/codes.ts
+++ b/src/error/codes.ts
@@ -101,6 +101,13 @@ enum ErrorCode {
   INTERCEPTOR_NEXT_FUNCTION_ALREADY_CALLED = 'ERR_INTERCEPTOR_NEXT_FUNCTION_ALREADY_CALLED',
 
   /**
+   * The provided cron string interval is invalid.
+   *
+   * @public
+   */
+  INVALID_CRON_STRING_INTERVAL = 'ERR_INVALID_CRON_STRING_INTERVAL',
+
+  /**
    * The listener has been destroyed and cannot be used any more.
    *
    * @public

--- a/src/error/messages.ts
+++ b/src/error/messages.ts
@@ -32,6 +32,8 @@ const ERROR_MESSAGE: { [K in ErrorCode]: string } = {
     'The database service is currently unavailable.',
   [ErrorCode.INTERCEPTOR_NEXT_FUNCTION_ALREADY_CALLED]:
     'The next function for this interceptor has already been called. Next functions may only be called once.',
+  [ErrorCode.INVALID_CRON_STRING_INTERVAL]:
+    'The provided cron string interval is invalid.',
   [ErrorCode.LISTENER_DESTROYED]:
     'Cannot destroy a listener that is already destroyed.',
   [ErrorCode.PROCESSING_ALREADY_FINISHED]:

--- a/src/test/task.spec.ts
+++ b/src/test/task.spec.ts
@@ -5,12 +5,11 @@
 
 import * as util from 'util';
 
-import * as uuid from 'uuid/v4';
-
 import TaskClient, {
   ErrorCode,
   Interceptors,
   IronTaskError,
+  Task,
   TaskClientOptions,
   TaskStatus
 } from '..';
@@ -376,11 +375,11 @@ describe('Task', () => {
     });
 
     it('captures information about the request', async () => {
-      const taskId = uuid();
+      let task: Task<any>;
 
       const taskInterceptor = jest.fn((async (ctx, next) => {
         expect(ctx.operation).toBe(Interceptors.TaskOperation.Save);
-        expect(ctx.task.id).toBe(taskId);
+        expect(ctx.task.id).toBe(task.id);
         expect(ctx.task.type).toBe(type);
         expect(ctx.ruConsumption).toBeUndefined();
         await next();
@@ -393,15 +392,11 @@ describe('Task', () => {
         }
       });
 
-      const task = await localClient.create(
-        type,
-        {
-          first: 'property',
-          second: 123,
-          arr: [true, false]
-        },
-        { id: taskId }
-      );
+      task = await localClient.create(type, {
+        first: 'property',
+        second: 123,
+        arr: [true, false]
+      });
 
       task.payload.first = 'updated';
       await task.save();
@@ -416,11 +411,11 @@ describe('Task', () => {
     });
 
     it('captures request errors', async () => {
-      const taskId = uuid();
+      let task: Task<any>;
 
       const taskInterceptor = jest.fn((async (ctx, next) => {
         expect(ctx.operation).toBe(Interceptors.TaskOperation.Save);
-        expect(ctx.task.id).toBe(taskId);
+        expect(ctx.task.id).toBe(task.id);
         expect(ctx.task.type).toBe(type);
         expect(ctx.ruConsumption).toBeUndefined();
         try {
@@ -441,20 +436,16 @@ describe('Task', () => {
         }
       });
 
-      const task = await localClient.create(
-        type,
-        {
-          first: 'property',
-          second: 123,
-          arr: [true, false]
-        },
-        { id: taskId }
-      );
+      task = await localClient.create(type, {
+        first: 'property',
+        second: 123,
+        arr: [true, false]
+      });
 
       task.payload.first = 'updated';
 
       // We delete from the main client so that we'll get an error
-      await client.deleteOne(type, taskId);
+      await client.deleteOne(type, task.id);
 
       try {
         await task.save();

--- a/src/utils/computeNextRun.ts
+++ b/src/utils/computeNextRun.ts
@@ -5,6 +5,8 @@
 
 import * as cron from 'cron-parser';
 
+import IronTaskError, { ErrorCode } from '../error';
+
 /**
  * Computes the unix ms epoch when the task should be run next from the interval,
  * if one is provided. If no time is returned, the task should not be run again.
@@ -20,10 +22,14 @@ export default function computeNextRun(
   // Cron strings are treated the same way regardless of whether this is a
   // first run or not. We just compute the next valid time and use it.
   if (typeof interval === 'string') {
-    return cron
-      .parseExpression(interval, { currentDate: previousStart || Date.now() })
-      .next()
-      .getTime();
+    try {
+      return cron
+        .parseExpression(interval, { currentDate: previousStart || Date.now() })
+        .next()
+        .getTime();
+    } catch (e) {
+      throw new IronTaskError(ErrorCode.INVALID_CRON_STRING_INTERVAL, e);
+    }
   }
 
   // For non-cron strings, the first run is always the current time by default


### PR DESCRIPTION
removes the option to specify a custom id when creating a task, which is needed to support a future feature to dynamically scale task capacity efficiently