### PR TITLE
fix(types): support Typescript < 3.4 again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3484,8 +3484,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3506,14 +3505,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3528,20 +3525,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3658,8 +3652,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3671,7 +3664,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3686,7 +3678,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3694,14 +3685,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3720,7 +3709,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3801,8 +3789,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3814,7 +3801,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3900,8 +3886,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3937,7 +3922,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3957,7 +3941,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4001,14 +3984,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12171,9 +12152,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "version": "3.3.4000",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "semantic-release": "^15.13.15",
     "ts-jest": "^24.0.2",
     "tslint": "^5.17.0",
-    "typescript": "^3.5.1"
+    "typescript": "^3.3.4000"
   },
   "files": [
     "/src/",

--- a/src/task/active.ts
+++ b/src/task/active.ts
@@ -761,8 +761,8 @@ export default class ActiveTaskImpl<T> extends EventEmitter
     };
   }
 
-  // tslint:disable-next-line:function-name
-  [util.inspect.custom](depth: number, opts: any) {
+  // We cast as any so that types behave outside of this library
+  [util.inspect.custom as any](depth: number, opts: any) {
     return this.toJSON();
   }
 }

--- a/src/task/readonly.ts
+++ b/src/task/readonly.ts
@@ -134,8 +134,8 @@ export default class ReadonlyTaskImpl<T> implements ReadonlyTask<T> {
     return this._data.toJSON();
   }
 
-  // tslint:disable-next-line:function-name
-  [util.inspect.custom](depth: number, opts: any) {
+  // We cast as any so that types behave outside of this library
+  [util.inspect.custom as any](depth: number, opts: any) {
     return this.toJSON();
   }
 }

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -144,8 +144,8 @@ export default class TaskImpl<T> implements Task<T> {
     return this._data.toJSON();
   }
 
-  // tslint:disable-next-line:function-name
-  [util.inspect.custom](depth: number, opts: any) {
+  // We cast as any so that types behave outside of this library
+  [util.inspect.custom as any](depth: number, opts: any) {
     return this.toJSON();
   }
 }


### PR DESCRIPTION
The update to typescript 3.5 caused types to be emitted as `readonly number[];` which causes a syntax error prior to Typescript 3.4. This increase in required Typescript version was accidental, so the version in the library has been moved back down to 3.3 to prevent this.

In addition, some consumers complain about the type of `util.inspect.custom` not being a unique symbol, so we cast it as any to make sure the type system complies. This isn't needed currently since Typescript 3.3 doesn't output that method in a .d.ts file, but it is there to future-proof.