### PR TITLE
fix(interceptors): use full URL for ref

### DIFF
--- a/src/test/client.spec.ts
+++ b/src/test/client.spec.ts
@@ -20,12 +20,14 @@ import initialize from './harness';
 
 describe('Client', () => {
   let client: TaskClient;
+  let containerRef: string;
   let getClient: (options: TaskClientOptions) => TaskClient;
   let cleanup: () => Promise<void>;
 
   beforeAll(async () => {
     const harness = await initialize();
     client = harness.client;
+    containerRef = harness.containerRef;
     getClient = harness.getClient;
     cleanup = harness.cleanup;
 
@@ -2995,6 +2997,9 @@ describe('Client', () => {
         expect(ctx.ruConsumption).toBeUndefined();
         await next();
         expect(ctx.ruConsumption).toBeGreaterThan(0);
+        expect(ctx.ref).toEqual(
+          expect.stringContaining(`${containerRef}/docs/`)
+        );
       }) as Interceptors.ClientRequestInterceptor);
 
       const localClient = getClient({

--- a/src/test/harness.ts
+++ b/src/test/harness.ts
@@ -3,6 +3,8 @@
  * Licensed under the MIT License.
  */
 
+import * as url from 'url';
+
 import { CosmosClient } from '@azure/cosmos';
 import uuid from 'uuid/v4';
 
@@ -49,6 +51,7 @@ export default async function initialize(options?: TaskClientOptions) {
     // production code.
     getClient: (options?: TaskClientOptions) =>
       new (TaskClient as any)((client as any)._client, options),
+    containerRef: url.resolve(account, `/dbs/${database}/colls/${collection}`),
     cleanup: async () => {
       const client = new CosmosClient({ endpoint: account, key });
       await client

--- a/src/test/listener.spec.ts
+++ b/src/test/listener.spec.ts
@@ -23,6 +23,7 @@ import initialize from './harness';
 
 describe('Listener', () => {
   let client: TaskClient;
+  let containerRef: string;
   let getClient: (options?: TaskClientOptions) => TaskClient;
   let cleanup: () => Promise<void>;
 
@@ -33,6 +34,7 @@ describe('Listener', () => {
       pollIntervalMs: 250
     });
     client = harness.client;
+    containerRef = harness.containerRef;
     getClient = harness.getClient;
     cleanup = harness.cleanup;
 
@@ -933,6 +935,7 @@ describe('Listener', () => {
       const processingInterceptor = jest.fn((async (ctx, next) => {
         expect(ctx.task.id).toBe(createdTask.id);
         expect(ctx.task.type).toBe(type);
+        expect(ctx.ref).toBe(`${containerRef}/docs/${createdTask.id}`);
         const result = await next();
         expect(result).toBe(ProcessingResult.Complete);
       }) as Interceptors.ProcessingInterceptor);

--- a/src/test/task.spec.ts
+++ b/src/test/task.spec.ts
@@ -18,12 +18,14 @@ import initialize from './harness';
 
 describe('Task', () => {
   let client: TaskClient;
+  let containerRef: string;
   let getClient: (options?: TaskClientOptions) => TaskClient;
   let cleanup: () => Promise<void>;
 
   beforeAll(async () => {
     const harness = await initialize();
     client = harness.client;
+    containerRef = harness.containerRef;
     getClient = harness.getClient;
     cleanup = harness.cleanup;
 
@@ -386,6 +388,7 @@ describe('Task', () => {
         expect(ctx.task.id).toBe(task.id);
         expect(ctx.task.type).toBe(type);
         expect(ctx.ruConsumption).toBeUndefined();
+        expect(ctx.ref).toBe(`${containerRef}/docs/${task.id}`);
         await next();
         expect(ctx.ruConsumption).toBeGreaterThan(0);
       }) as Interceptors.TaskRequestInterceptor);


### PR DESCRIPTION
The URL for a ref in an interceptor is supposed to be a full URL rather than just the pathname. This fixes that