### PR TITLE
ci: lock to Node.js 8.16.2 to guarantee npm ci availability

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,8 +28,8 @@ jobs:
         displayName: Run Azure Cosmos DB Emulator
       - task: NodeTool@0
         inputs:
-          versionSpec: 8.x
-        displayName: Use Node.js 8.x
+          versionSpec: 8.16.2
+        displayName: Use Node.js 8.16.2
       - script: npm ci
         displayName: Install Dependencies
       - script: npm test


### PR DESCRIPTION
The Azure Pipelines CI build is picking up older versions of Node.js 8.x which don't have NPM 6 installed and therefore are unable to run `npm ci`, causing the build to fail. This change locks the task to version 8.16.2 to ensure that `npm ci` works.