### PR TITLE
feat(query): use new offset and limit params for paging

### DIFF
--- a/docs/cosmos-features.md
+++ b/docs/cosmos-features.md
@@ -6,15 +6,6 @@ implemented or improved in the future, please tell the Cosmos DB team that you
 would like the corresponding backing features implemented in the database by
 voting for them using the feedback links below.
 
-### Task Priority
-
-To support handling task priority (either high/low or numerical) efficiently, it
-is necessary to have support for ordering query results by multiple fields. To
-do so, we need support for it in the database. See the page below to vote for
-this feature:
-
-https://feedback.azure.com/forums/263030-azure-cosmos-db/suggestions/16883608-allow-multi-order-by
-
 ### Efficient Listing of Large Sets of Tasks
 
 When listing large sets of tasks, we paginate the results by default to reduce
@@ -25,6 +16,10 @@ efficient paging, we need to be able to skip the earlier pages in the database
 itself. See the page below to vote for this feature:
 
 https://feedback.azure.com/forums/263030-azure-cosmos-db/suggestions/6350987--documentdb-allow-paging-skip-take
+
+> NOTE: this feature has been implemented in Cosmos DB but still has suboptimal
+> performance at time of writing. See the linked feedback item for more
+> information.
 
 ### Efficient Updates
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -257,10 +257,9 @@ export default class TaskClient {
     const skip = options.skip || 0;
     const top = options.top || DEFAULT_PAGE_SIZE;
 
-    // TODO: no skip support yet in Cosmos DB so we have to do the skip
-    // client side for now.
     const query = buildQuery({
-      limit: skip + top,
+      offset: skip,
+      limit: top,
       filter: typeFilter(type, options.filter),
       sort: options.sortExpression,
       sortOrder: options.sortOrder
@@ -277,9 +276,9 @@ export default class TaskClient {
         >(query);
         return {
           ...response,
-          result: response.result
-            .slice(skip)
-            .map(doc => TaskImpl.create(this._client, this._interceptor, doc))
+          result: response.result.map(doc =>
+            TaskImpl.create(this._client, this._interceptor, doc)
+          )
         };
       }
     );
@@ -347,10 +346,9 @@ export default class TaskClient {
     const skip = options.skip || 0;
     const top = options.top || DEFAULT_PAGE_SIZE;
 
-    // TODO: no skip support yet in Cosmos DB so we have to do the skip
-    // client side for now.
     const query = buildQuery({
-      limit: skip + top,
+      offset: skip,
+      limit: top,
       filter: options.filter,
       sort: options.sortExpression,
       sortOrder: options.sortOrder
@@ -367,9 +365,9 @@ export default class TaskClient {
         >(query);
         return {
           ...response,
-          result: response.result
-            .slice(skip)
-            .map(doc => TaskImpl.create(this._client, this._interceptor, doc))
+          result: response.result.map(doc =>
+            TaskImpl.create(this._client, this._interceptor, doc)
+          )
         };
       }
     );
@@ -399,10 +397,9 @@ export default class TaskClient {
     const skip = options.skip || 0;
     const top = options.top || DEFAULT_PAGE_SIZE;
 
-    // TODO: no skip support yet in Cosmos DB so we have to do the skip
-    // client side for now.
     const query = buildQuery({
-      limit: skip + top,
+      offset: skip,
+      limit: top,
       projection: summaryProjection(options.project),
       filter: typeFilter(type, options.filter),
       sort: options.sortExpression,
@@ -420,11 +417,9 @@ export default class TaskClient {
         >(query);
         return {
           ...response,
-          result: response.result
-            .slice(skip)
-            .map(doc =>
-              ReadonlyTaskImpl.create(this._client, this._interceptor, doc)
-            )
+          result: response.result.map(doc =>
+            ReadonlyTaskImpl.create(this._client, this._interceptor, doc)
+          )
         };
       }
     );
@@ -510,10 +505,9 @@ export default class TaskClient {
     const skip = options.skip || 0;
     const top = options.top || DEFAULT_PAGE_SIZE;
 
-    // TODO: no skip support yet in Cosmos DB so we have to do the skip
-    // client side for now.
     const query = buildQuery({
-      limit: skip + top,
+      offset: skip,
+      limit: top,
       projection: summaryProjection(options.project),
       filter: options.filter,
       sort: options.sortExpression,
@@ -531,11 +525,9 @@ export default class TaskClient {
         >(query);
         return {
           ...response,
-          result: response.result
-            .slice(skip)
-            .map(doc =>
-              ReadonlyTaskImpl.create(this._client, this._interceptor, doc)
-            )
+          result: response.result.map(doc =>
+            ReadonlyTaskImpl.create(this._client, this._interceptor, doc)
+          )
         };
       }
     );


### PR DESCRIPTION
Cosmos DB has added a new OFFSET LIMIT construct for doing paging. It doesn't do much for database performance, but reduces the data that has to round trip to the client. Using it also allows the engine to make more optimizations in the future with no client changes needed.