### PR TITLE
feat: skip past task occurrences when enabling a disabled task

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -49,6 +49,7 @@ import {
   TaskClientOptions,
   TaskHandler
 } from './types';
+import { TaskEnableOptions } from '../types/public';
 
 // Async iterator polyfill for Node <10
 if (!Symbol.asyncIterator) {
@@ -837,16 +838,17 @@ export default class TaskClient {
    * @param type    - Task type
    * @param filter  - Query filter specifying which tasks within the provided
    *                  type to enable
+   * @param options - Task enable options
    *
    * @public
    */
-  async enable(type: string, filter?: QueryType.Bool): Promise<void> {
+  async enable(type: string, filter?: QueryType.Bool, options?: TaskEnableOptions): Promise<void> {
     await this._bulkUpdate(
       Interceptors.TaskClientOperation.Enable,
       Interceptors.TaskOperation.Enable,
       type,
       buildQuery({ filter: typeFilter(type, filter) }),
-      async task => task.enable()
+      async task => task.enable(options)
     );
   }
 
@@ -861,16 +863,17 @@ export default class TaskClient {
    * especially when paging and/or sorting results. Use this API with care.
    *
    * @param filter  - Query filter specifying which tasks to enable
+   * @param options - Task enable options
    *
    * @public
    */
-  async enableAll(filter?: QueryType.Bool): Promise<void> {
+  async enableAll(filter?: QueryType.Bool, options?: TaskEnableOptions): Promise<void> {
     await this._bulkUpdate(
       Interceptors.TaskClientOperation.EnableAll,
       Interceptors.TaskOperation.Enable,
       undefined,
       buildQuery({ filter }),
-      async task => task.enable()
+      async task => task.enable(options)
     );
   }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -30,6 +30,7 @@ import {
   typeFilter
 } from '../task';
 import { Omit, RecursiveRequired } from '../types/internal';
+import { TaskEnableOptions } from '../types/public';
 import batchIterator from '../utils/batchIterator';
 import computeNextRun from '../utils/computeNextRun';
 
@@ -49,7 +50,6 @@ import {
   TaskClientOptions,
   TaskHandler
 } from './types';
-import { TaskEnableOptions } from '../types/public';
 
 // Async iterator polyfill for Node <10
 if (!Symbol.asyncIterator) {
@@ -842,7 +842,11 @@ export default class TaskClient {
    *
    * @public
    */
-  async enable(type: string, filter?: QueryType.Bool, options?: TaskEnableOptions): Promise<void> {
+  async enable(
+    type: string,
+    filter?: QueryType.Bool,
+    options?: TaskEnableOptions
+  ): Promise<void> {
     await this._bulkUpdate(
       Interceptors.TaskClientOperation.Enable,
       Interceptors.TaskOperation.Enable,
@@ -867,7 +871,10 @@ export default class TaskClient {
    *
    * @public
    */
-  async enableAll(filter?: QueryType.Bool, options?: TaskEnableOptions): Promise<void> {
+  async enableAll(
+    filter?: QueryType.Bool,
+    options?: TaskEnableOptions
+  ): Promise<void> {
     await this._bulkUpdate(
       Interceptors.TaskClientOperation.EnableAll,
       Interceptors.TaskOperation.Enable,

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -7,6 +7,8 @@ import * as util from 'util';
 
 import { CosmosDbClient } from '../client';
 import Interceptors, { InterceptorProcessor } from '../interceptor';
+import { TaskEnableOptions } from '../types/public';
+import computeNextRun from '../utils/computeNextRun';
 
 import TaskData from './data';
 import { ResolvedTaskDocument } from './document';
@@ -101,12 +103,21 @@ export default class TaskImpl<T> implements Task<T> {
     );
   }
 
-  async enable(): Promise<void> {
+  async enable(options?: TaskEnableOptions): Promise<void> {
+    let patchOp = async () => this._data.patch(() => ({ enabled: true }));
+
+    // Patch task with enable options
+    if (options && !!options.recomputeNextRunTime) {
+      const nextRunTime = computeNextRun(this._data.interval, Date.now());
+      patchOp = async () =>
+        this._data.patch(() => ({ enabled: true, nextRunTime }));
+    }
+
     await this._interceptor.task(
       this,
       Interceptors.TaskOperation.Enable,
       this._data.ref,
-      async () => this._data.patch(() => ({ enabled: true }))
+      patchOp
     );
   }
 
@@ -178,8 +189,9 @@ export interface Task<T> extends TaskBase<T> {
    * Enable the task for processing.
    *
    * @public
+   * @param options Task Enable Options
    */
-  enable(): Promise<void>;
+  enable(options?: TaskEnableOptions): Promise<void>;
 
   /**
    * Disable the task for processing. If the task is currently running, the

--- a/src/types/public.ts
+++ b/src/types/public.ts
@@ -55,3 +55,14 @@ export interface TimeoutsOptions {
    */
   retries?: number;
 }
+
+export interface TaskEnableOptions {
+  /**
+   * Enable a recurring task and recompute next run time
+   *
+   * @defaultValue false
+   *
+   * @public
+   */
+  recomputeNextRunTime?: boolean;
+}

--- a/src/utils/computeNextRun.ts
+++ b/src/utils/computeNextRun.ts
@@ -13,7 +13,7 @@ import IronTaskError, { ErrorCode } from '../error';
  *
  * @param interval      Number of milliseconds between runs or cron string.
  * @param previousStart If there was a previous run, the time when that run
- *                      started
+ *                      started.
  */
 export default function computeNextRun(
   interval?: string | number,


### PR DESCRIPTION
Add TaskEnableOptions as an optional parameter to be used to modify task when enabling a task. This PR only gives recomputeNextRunTime as an option to recompute the next run time of a disabled scheduled task while enabling it