### PR TITLE
feat: add support for last day of the month cron string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3911,12 +3911,12 @@
       }
     },
     "cron-parser": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.13.0.tgz",
-      "integrity": "sha512-UWeIpnRb0eyoWPVk+pD3TDpNx3KCFQeezO224oJIkktBrcW6RoAPOx5zIKprZGfk6vcYSmA8yQXItejSaDBhbQ==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.17.0.tgz",
+      "integrity": "sha512-oTmzVEwlurRe51HqTm4afshVr8Rkxy9kFiWxh5e6SmrY2o9NDYU4S6SduanBZYXLgkLy0skA98y7/tztW/DmjQ==",
       "requires": {
-        "is-nan": "^1.2.1",
-        "moment-timezone": "^0.5.25"
+        "is-nan": "^1.3.0",
+        "moment-timezone": "^0.5.31"
       }
     },
     "cross-spawn": {
@@ -8894,9 +8894,9 @@
       "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg=="
     },
     "moment-timezone": {
-      "version": "0.5.28",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
-      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
+      "version": "0.5.31",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
+      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.6.3",
-    "cron-parser": "^2.13.0",
+    "cron-parser": "^2.17.0",
     "json-merge-patch": "^0.2.3",
     "lodash.clonedeep": "^4.5.0",
     "p-queue": "^6.4.0",

--- a/src/utils/computeNextRun.spec.ts
+++ b/src/utils/computeNextRun.spec.ts
@@ -90,4 +90,17 @@ describe('#computeNextRun', () => {
     // Every 5 minutes
     expect(computeNextRun('*/12 * * * *', previous)).toBe(nextRun);
   });
+
+  it('sets the time to the last day of the month', () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const lastDayOfMonth = moment()
+      .endOf('month')
+      .date();
+    const nextRuntime = computeNextRun('10 20 L * *');
+
+    expect(nextRuntime).toBeDefined();
+    expect(new Date(nextRuntime!).getDate()).toBe(lastDayOfMonth);
+  });
 });


### PR DESCRIPTION
Add support to run a task on the last day of the month using cron parsing.
eg format 10 20 L * * will run a task at the 10th minute of the 20th hour on the last day of the month (28th/29th/30th/31st)