### PR TITLE
ci: switch github credential for publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,4 @@
 name: 'Continuous Integration'
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
 on:
   push:
     branches:
@@ -88,4 +84,4 @@ jobs:
         run: npm run release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Removes specific permissions for the built-in github token and switches to a PAT that can bypass branch protections to publish