### PR TITLE
ci: avoid persisting credentials on checkout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Following guidance from here: https://github.com/cycjimmy/semantic-release-action?tab=readme-ov-file#usage